### PR TITLE
fix: 不支持不带https://的链接 https://github.com/moeyy01/gh-proxy-go/issues/6

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,8 +112,9 @@ func handler(c *gin.Context) {
 	}
 
 	if !strings.HasPrefix(rawPath, "http") {
-		c.String(http.StatusForbidden, "Invalid input.")
-		return
+		// c.String(http.StatusForbidden, "Invalid input.")
+		// return
+		rawPath = fmt.Sprintf("https://%s", rawPath)
 	}
 
 	matches := checkURL(rawPath)


### PR DESCRIPTION
其他的代理确实支持不带https://前缀的。